### PR TITLE
Add Amplitron - open-source guitar amp simulator with audio visualization

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -112,8 +112,8 @@
 - [audioMotion](https://audiomotion.me) - High-resolution real-time audio spectrum analyzer and full-featured music player written in JavaScript. Includes binaries for Windows, Linux and macOS.
 - [p5.js Audio Visualizer](https://amandayehh.github.io/audio-visualizer/) - A powerful, beat- and amplitude-responsive audio visualizer created with [p5.sound](https://github.com/processing/p5.js-sound), on an HTML5 Canvas by Amanda Yeh.
 - [Tap tempo and metronome with sound effects](https://tapbpmhub.com/) - A metronome with customizable sound effects, capable of calculating bpm with just a click, and also supports synchronization with your MIDI device.
-- [osci-render](https://github.com/jameshball/osci-render) - Software for making music by visualising objects, images, and Blender scenes on an oscilloscope using audio.
-
+- [osci-render](https://github.com/jameshball/osci-render) - Software for making music by visualising objects, images, and Blender scenes on an oscilloscope using
+- [Amplitron](https://github.com/sudip-mondal-2002/Amplitron) - A real-time guitar amp simulator with audio visualization, multi-effects, and a web-based demo.
 
 ## Experiments on Codepen
 


### PR DESCRIPTION
This PR adds [Amplitron](https://github.com/sudip-mondal-2002/Amplitron) to the list.

Amplitron is an open-source, real-time guitar amp simulator with audio visualization, multi-effects, and a web-based demo.