### PR TITLE
Add Vizz.fm to Experiments

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -113,7 +113,7 @@
 - [p5.js Audio Visualizer](https://amandayehh.github.io/audio-visualizer/) - A powerful, beat- and amplitude-responsive audio visualizer created with [p5.sound](https://github.com/processing/p5.js-sound), on an HTML5 Canvas by Amanda Yeh.
 - [Tap tempo and metronome with sound effects](https://tapbpmhub.com/) - A metronome with customizable sound effects, capable of calculating bpm with just a click, and also supports synchronization with your MIDI device.
 - [osci-render](https://github.com/jameshball/osci-render) - Software for making music by visualising objects, images, and Blender scenes on an oscilloscope using audio.
-
+- [Vizz.fm](https://vizz.fm) - A browser-based music visualizer using Three.js and the Web Audio API.
 
 ## Experiments on Codepen
 


### PR DESCRIPTION
Adds [Vizz.fm](https://vizz.fm) to the Experiments section.

It's a browser-based music visualizer built with Three.js and the Web Audio API — fits alongside the other in-browser audio experiments in that list. Placed it right after PartyMode (which I also made like 12 years ago lol)