### PR TITLE
Add Tonalux Audio Analyzer to Experiments

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -110,6 +110,7 @@
 - [YouTube Musical Spectrum](https://github.com/mfcc64/youtube-musical-spectrum) - A browser extension that offers audio visualization on your YouTube page with nice musical notes.
 - [Just Dance](http://hiteshsahu.com/AudioAnalysis) - A 3D Audio Visualization made with [BabylonJS](http://babylonjs.com/) & 2D Perlin Noise.
 - [audioMotion](https://audiomotion.me) - High-resolution real-time audio spectrum analyzer and full-featured music player written in JavaScript. Includes binaries for Windows, Linux and macOS.
+- [Tonalux Audio Analyzer](https://tonalux.org/analyzer.html) - Free browser-based real-time spectrum analyzer with waveform display and LUFS loudness metering. No installation required.
 - [p5.js Audio Visualizer](https://amandayehh.github.io/audio-visualizer/) - A powerful, beat- and amplitude-responsive audio visualizer created with [p5.sound](https://github.com/processing/p5.js-sound), on an HTML5 Canvas by Amanda Yeh.
 - [Tap tempo and metronome with sound effects](https://tapbpmhub.com/) - A metronome with customizable sound effects, capable of calculating bpm with just a click, and also supports synchronization with your MIDI device.
 - [osci-render](https://github.com/jameshball/osci-render) - Software for making music by visualising objects, images, and Blender scenes on an oscilloscope using audio.


### PR DESCRIPTION
Adds [Tonalux Audio Analyzer](https://tonalux.org/analyzer.html) to the Experiments section.

It's a free, browser-based real-time audio spectrum analyzer with waveform display and LUFS loudness metering. Runs entirely in the browser using the Web Audio API, no installation or account needed.