### PR TITLE
Add VPX-Scope to Experiments

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -117,6 +117,7 @@
 - [Nutilz Audio Waveform Generator](https://nutilz.com/audio-waveform-generator) - Upload an MP3, WAV, OGG, M4A or FLAC file and instantly generate a customizable waveform visualization (bars, mirrored bars, or line) using the Web Audio API, downloadable as a PNG. Runs entirely in the browser, no upload.
 
 - [DjMirror Pulse](https://djmirror.com/) - Real-time audio-reactive visuals and DMX lighting control for live DJ sets, as a standalone desktop application.
+- [VPX-Scope](https://vpx-scope.vercel.app/en/) - Drop a tracker module (.mod, .xm, .it, .s3m) or an MP3/FLAC and watch a per-channel rainbow oscilloscope, one waveform per voice, coloured by zero-crossing rate. Uses libopenmpt compiled to WebAssembly and runs entirely in the tab, nothing is uploaded.
 
 ## Experiments on Codepen
 


### PR DESCRIPTION
Adds **VPX-Scope** to the Experiments section.

It is a free web page where you drop a tracker module (.mod, .xm, .it, .s3m) or a regular MP3/FLAC and get a per-channel oscilloscope: one waveform per voice, coloured by zero-crossing rate (green to amber to red), so you can literally see the bass line and the lead as separate traces. It uses libopenmpt compiled to WebAssembly and decodes everything in the tab, so nothing is uploaded anywhere.

Closest neighbours already on the list are osci-render and the Master Pro Audio Analyzer Suite; the tracker/per-channel angle is the part none of the current entries cover.

Full disclosure: I wrote it. It is free, no signup, no ads. Link checked, returns 200.