### PR TITLE
Add sgram-tui to Downloads

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,7 +43,8 @@
 - [Music Radar](http://www.musicradar.com/news/tech/free-music-samples-download-loops-hits-and-multis-627820)
 - [How to Make Electronic Music Freebies](http://howtomakeelectronicmusic.com/category/freebies)
 - [Motion Sound](http://motionsound.io/)
-- [Cava](https://github.com/karlstav/cava#latency-notes) - A cross-platform terminal visualizer. 
+- [Cava](https://github.com/karlstav/cava#latency-notes) - A cross-platform terminal visualizer.
+- [sgram-tui](https://github.com/arian-shamaei/sgram-tui) - A calibrated terminal spectrogram analyzer with live mic input and labeled PNG figure export. 
 
 
 ## Experiments


### PR DESCRIPTION
Adds [sgram-tui](https://github.com/arian-shamaei/sgram-tui) next to Cava — a calibrated spectrogram analyzer for the terminal: live mic or audio files, mouse-hover time/frequency/dB readout, and labeled PNG figure export with a headless render mode. Rust, MIT.

![sgram-tui rendering audio that spells its own name](https://raw.githubusercontent.com/arian-shamaei/sgram-tui/main/docs/assets/hero-spell.png)